### PR TITLE
Add monthly timecard summary

### DIFF
--- a/src/features/timecard/Timecard.tsx
+++ b/src/features/timecard/Timecard.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { Container, Stack, Box, Typography, useTheme } from '@mui/material';
+import React, { useState } from 'react';
+import { Container, Stack, Box, Typography, useTheme, TextField } from '@mui/material';
 import { TimecardForm } from './TimecardForm';
 import { TimecardList } from './TimecardList';
+import TimecardSummary from './TimecardSummary';
 import { 
   FadeIn, 
   SlideUp, 
@@ -13,6 +14,7 @@ import { spacingTokens, shapeTokens } from '../../theme/designSystem';
 
 const Timecard: React.FC = () => {
   const theme = useTheme();
+  const [month, setMonth] = useState(() => new Date().toISOString().slice(0, 7));
 
   return (
     <Box sx={{ 
@@ -65,10 +67,26 @@ const Timecard: React.FC = () => {
             <Stack spacing={spacingTokens.xl}>
               <StaggerItem>
                 <SlideUp>
+                  <Stack spacing={spacingTokens.md}>
+                    <TextField
+                      label="対象月"
+                      type="month"
+                      value={month}
+                      onChange={(e) => setMonth(e.target.value)}
+                      size="small"
+                      InputLabelProps={{ shrink: true }}
+                    />
+                    <TimecardSummary month={month} />
+                  </Stack>
+                </SlideUp>
+              </StaggerItem>
+
+              <StaggerItem>
+                <SlideUp>
                   <TimecardForm />
                 </SlideUp>
               </StaggerItem>
-              
+
               <StaggerItem>
                 <SlideUp>
                   <TimecardList />

--- a/src/features/timecard/TimecardSummary.tsx
+++ b/src/features/timecard/TimecardSummary.tsx
@@ -1,0 +1,61 @@
+import React, { useMemo } from 'react';
+import { Paper, Stack, Typography, Box, useTheme } from '@mui/material';
+import { useTimecardStore, TimecardEntry } from './useTimecardStore';
+import { calculateDuration } from './utils';
+
+interface TimecardSummaryProps {
+  month: string; // YYYY-MM
+}
+
+export const TimecardSummary: React.FC<TimecardSummaryProps> = ({ month }) => {
+  const theme = useTheme();
+  const entries = useTimecardStore((s) => s.entries);
+
+  const summary = useMemo(() => {
+    let totalHours = 0;
+    let vacation = 0;
+    let planned = 0;
+    let sudden = 0;
+
+    entries.forEach((e: TimecardEntry) => {
+      if (!e.date.startsWith(month)) return;
+      if (e.isAbsence) {
+        vacation += 1;
+        if (e.absenceType === 'planned') planned += 1;
+        if (e.absenceType === 'sudden') sudden += 1;
+      } else if (e.startTime && e.endTime) {
+        totalHours += calculateDuration(e.startTime, e.endTime);
+      }
+    });
+
+    return { totalHours, vacation, planned, sudden };
+  }, [entries, month]);
+
+  return (
+    <Paper elevation={3} sx={{ p: 2, borderRadius: 2 }}>
+      <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 1 }}>
+        月次サマリー
+      </Typography>
+      <Stack direction="row" spacing={2}>
+        <Box>
+          <Typography variant="body2" color="text.secondary">
+            合計時間
+          </Typography>
+          <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
+            {summary.totalHours.toFixed(1)}h
+          </Typography>
+        </Box>
+        <Box>
+          <Typography variant="body2" color="text.secondary">
+            休暇日数
+          </Typography>
+          <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
+            {summary.vacation}日（計画 {summary.planned}・突発 {summary.sudden}）
+          </Typography>
+        </Box>
+      </Stack>
+    </Paper>
+  );
+};
+
+export default TimecardSummary;

--- a/src/features/timecard/index.ts
+++ b/src/features/timecard/index.ts
@@ -1,6 +1,7 @@
 export { default as Timecard } from "./Timecard";
 export { TimecardForm } from './TimecardForm';
 export { TimecardList } from './TimecardList';
+export { default as TimecardSummary } from './TimecardSummary';
 export { useTimecardStore } from './useTimecardStore';
 export type {
   TimecardEntry,

--- a/src/features/timecard/useTimecardStore.ts
+++ b/src/features/timecard/useTimecardStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { calculateDuration } from './utils';
 
 export interface TimecardEntry {
   id: string;
@@ -65,3 +66,16 @@ export const useTimecardStore = create<TimecardStore>((set) => ({
     })),
   reset: () => set(initialState),
 }));
+
+/**
+ * 月別の合計勤務時間を計算する
+ */
+export const calculateMonthlyHours = (
+  entries: TimecardEntry[],
+): Record<string, number> =>
+  entries.reduce<Record<string, number>>((acc, e) => {
+    if (e.isAbsence || !e.startTime || !e.endTime) return acc;
+    const month = e.date.slice(0, 7);
+    acc[month] = (acc[month] ?? 0) + calculateDuration(e.startTime, e.endTime);
+    return acc;
+  }, {});

--- a/src/features/timecard/utils.ts
+++ b/src/features/timecard/utils.ts
@@ -1,0 +1,5 @@
+export const calculateDuration = (start: string, end: string): number => {
+  const [sh, sm] = start.split(":").map(Number);
+  const [eh, em] = end.split(":").map(Number);
+  return (eh * 60 + em - (sh * 60 + sm)) / 60;
+};


### PR DESCRIPTION
## Summary
- compute monthly work hours in `useTimecardStore`
- provide `calculateDuration` helper
- create `TimecardSummary` component to show totals for the selected month
- show summary and month filter in `Timecard`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f4929e8cc833385d77e8be8975c17