### PR TITLE
Add expense management feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ const TeamShuffle = React.lazy(() => import('./features/teamShuffle/TeamShuffle'
 const MeetingFlow = React.lazy(() => import('./features/meetingFlow/MeetingFlow'));
 const EmployeeRegister = React.lazy(() => import('./features/employeeRegister/EmployeeRegister').then(module => ({ default: module.EmployeeRegister })));
 const Timecard = React.lazy(() => import("./features/timecard/Timecard"));
+const Expense = React.lazy(() => import('./features/expense/Expense'));
 
 // メインアプリコンテンツ
 function AppContent() {
@@ -173,6 +174,16 @@ function AppContent() {
                         setTeams={setTeams}
                         members={members}
                       />
+                    </Suspense>
+                  </ScrollableContent>
+                </PageTransition>
+              </TabPanel>
+
+              <TabPanel value={currentTab} index={4}>
+                <PageTransition mode="fade" key="expense">
+                  <ScrollableContent>
+                    <Suspense fallback={<PageLoader message="経費管理を読み込み中..." />}>
+                      <Expense />
                     </Suspense>
                   </ScrollableContent>
                 </PageTransition>

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -10,9 +10,10 @@ import {
   useMediaQuery
 } from '@mui/material';
 import { 
-  Shuffle as ShuffleIcon, 
+  Shuffle as ShuffleIcon,
   People as PeopleIcon,
   AccessTime as TimeIcon,
+  ReceiptLong as ReceiptLongIcon,
   Menu as MenuIcon,
   Dashboard as DashboardIcon
 } from '@mui/icons-material';
@@ -100,6 +101,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
               <Tab icon={<ShuffleIcon />} label="チーム分け" />
               <Tab icon={<PeopleIcon />} label="社員管理" />
               <Tab icon={<TimeIcon />} label="勤怠管理" />
+              <Tab icon={<ReceiptLongIcon />} label="経費管理" />
             </Tabs>
           )}
 

--- a/src/components/navigation/MobileNavDrawer.tsx
+++ b/src/components/navigation/MobileNavDrawer.tsx
@@ -15,6 +15,7 @@ import {
   People as PeopleIcon,
   MeetingRoom as MeetingIcon, 
   AccessTime as TimeIcon,
+  ReceiptLong as ExpenseIcon,
   Settings as SettingsIcon,
   Speed as SpeedIcon,
   Dashboard as DashboardIcon
@@ -60,6 +61,7 @@ export const MobileNavDrawer: React.FC<MobileNavDrawerProps> = ({
     { icon: <MeetingIcon />, label: 'ミーティング進行', index: 3 },
     { icon: <PeopleIcon />, label: '社員管理', index: 1 },
     { icon: <TimeIcon />, label: '勤怠管理', index: 2 },
+    { icon: <ExpenseIcon />, label: '経費管理', index: 4 },
   ];
 
   const settingsNavigationItems = [

--- a/src/components/navigation/SideNavigation.tsx
+++ b/src/components/navigation/SideNavigation.tsx
@@ -26,6 +26,7 @@ import {
   MeetingRoom as MeetingIcon,
   People as PeopleIcon,
   AccessTime as TimeIcon,
+  ReceiptLong as ExpenseIcon,
   Settings as SettingsIcon,
   Speed as SpeedIcon,
   ExpandLess,
@@ -100,6 +101,12 @@ export const SideNavigation: React.FC<SideNavigationProps> = ({
       label: '勤怠管理',
       icon: <TimeIcon />,
       index: 2,
+    },
+    {
+      id: 'expense',
+      label: '経費管理',
+      icon: <ExpenseIcon />,
+      index: 4,
     },
   ];
 

--- a/src/features/expense/Expense.tsx
+++ b/src/features/expense/Expense.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Container, Box, Typography, useTheme } from '@mui/material';
+import { ExpenseForm } from './ExpenseForm';
+import { ExpenseList } from './ExpenseList';
+import { FadeIn } from '../../components/ui/Animation/MotionComponents';
+import { surfaceStyles } from '../../theme/componentStyles';
+
+const Expense: React.FC = () => {
+  const theme = useTheme();
+  const [month, setMonth] = useState(() => new Date().toISOString().slice(0, 7));
+
+  return (
+    <Box sx={{
+      height: '100vh',
+      overflow: 'hidden',
+      display: 'flex',
+      flexDirection: 'column',
+      background: `linear-gradient(135deg, ${theme.palette.background.default} 0%, ${theme.palette.background.paper} 100%)`,
+    }}>
+      <FadeIn>
+        <Box sx={{
+          py: 3,
+          px: 2,
+          ...surfaceStyles.glassmorphism(theme),
+          borderBottom: `1px solid ${theme.palette.divider}`,
+          flexShrink: 0,
+        }}>
+          <Typography variant="h4" sx={{ fontWeight: 'bold', textAlign: 'center' }}>
+            経費管理
+          </Typography>
+        </Box>
+      </FadeIn>
+      <Box sx={{ flex: 1, overflow: 'auto', p: 2 }}>
+        <Container maxWidth="md">
+          <ExpenseForm />
+          <Box sx={{ mt: 3 }}>
+            <ExpenseList />
+          </Box>
+        </Container>
+      </Box>
+    </Box>
+  );
+};
+
+export default Expense;

--- a/src/features/expense/ExpenseForm.tsx
+++ b/src/features/expense/ExpenseForm.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import {
+  Paper,
+  TextField,
+  Stack,
+  Button,
+  Typography,
+} from '@mui/material';
+import { useExpenseStore } from './useExpenseStore';
+
+export const ExpenseForm: React.FC = () => {
+  const { addExpense } = useExpenseStore();
+  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [category, setCategory] = useState('');
+  const [amount, setAmount] = useState(0);
+  const [note, setNote] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    addExpense({ date, category, amount, note });
+    setCategory('');
+    setAmount(0);
+    setNote('');
+  };
+
+  return (
+    <Paper elevation={3} sx={{ p: 3, borderRadius: 2, maxWidth: 400, mx: 'auto' }}>
+      <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 2 }}>
+        経費登録
+      </Typography>
+      <Stack component="form" onSubmit={handleSubmit} spacing={2}>
+        <TextField
+          label="日付"
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          InputLabelProps={{ shrink: true }}
+        />
+        <TextField
+          label="カテゴリ"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+        />
+        <TextField
+          label="金額"
+          type="number"
+          value={amount}
+          onChange={(e) => setAmount(Number(e.target.value))}
+        />
+        <TextField
+          label="備考"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          multiline
+          rows={2}
+        />
+        <Button type="submit" variant="contained">
+          登録
+        </Button>
+      </Stack>
+    </Paper>
+  );
+};

--- a/src/features/expense/ExpenseList.tsx
+++ b/src/features/expense/ExpenseList.tsx
@@ -1,0 +1,143 @@
+import React, { useState } from 'react';
+import {
+  Paper,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+  Stack,
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import { useExpenseStore } from './useExpenseStore';
+
+interface EditForm {
+  date: string;
+  category: string;
+  amount: number;
+  note?: string;
+}
+
+export const ExpenseList: React.FC = () => {
+  const { expenses, deleteExpense, updateExpense } = useExpenseStore();
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState<EditForm>({
+    date: '',
+    category: '',
+    amount: 0,
+    note: '',
+  });
+
+  const openEdit = (id: string) => {
+    const entry = expenses.find((e) => e.id === id);
+    if (!entry) return;
+    setForm({
+      date: entry.date,
+      category: entry.category,
+      amount: entry.amount,
+      note: entry.note ?? '',
+    });
+    setEditingId(id);
+  };
+
+  const closeEdit = () => setEditingId(null);
+
+  const handleSave = () => {
+    if (!editingId) return;
+    updateExpense(editingId, form);
+    closeEdit();
+  };
+
+  return (
+    <Paper elevation={3} sx={{ p: 3, borderRadius: 2 }}>
+      <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 2 }}>
+        経費一覧
+      </Typography>
+      {expenses.length === 0 ? (
+        <Typography color="text.secondary">まだ登録がありません</Typography>
+      ) : (
+        <TableContainer component={Paper} sx={{ borderRadius: 1 }}>
+          <Table>
+            <TableHead>
+              <TableRow sx={{ backgroundColor: 'rgba(0,0,0,0.04)' }}>
+                <TableCell>日付</TableCell>
+                <TableCell>カテゴリ</TableCell>
+                <TableCell>金額</TableCell>
+                <TableCell>備考</TableCell>
+                <TableCell align="center">操作</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {expenses.map((entry) => (
+                <TableRow key={entry.id}>
+                  <TableCell>{entry.date}</TableCell>
+                  <TableCell>{entry.category}</TableCell>
+                  <TableCell>{entry.amount}</TableCell>
+                  <TableCell>{entry.note}</TableCell>
+                  <TableCell align="center">
+                    <IconButton size="small" color="primary" onClick={() => openEdit(entry.id)}>
+                      <EditIcon fontSize="small" />
+                    </IconButton>
+                    <IconButton size="small" color="error" onClick={() => deleteExpense(entry.id)}>
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+      <Dialog open={!!editingId} onClose={closeEdit}>
+        <DialogTitle sx={{ fontWeight: 'bold' }}>経費編集</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <TextField
+              label="日付"
+              type="date"
+              value={form.date}
+              onChange={(e) => setForm({ ...form, date: e.target.value })}
+              InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+              label="カテゴリ"
+              value={form.category}
+              onChange={(e) => setForm({ ...form, category: e.target.value })}
+            />
+            <TextField
+              label="金額"
+              type="number"
+              value={form.amount}
+              onChange={(e) => setForm({ ...form, amount: Number(e.target.value) })}
+            />
+            <TextField
+              label="備考"
+              value={form.note}
+              onChange={(e) => setForm({ ...form, note: e.target.value })}
+              multiline
+              rows={2}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeEdit} variant="outlined">
+            キャンセル
+          </Button>
+          <Button onClick={handleSave} variant="contained">
+            保存
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Paper>
+  );
+};

--- a/src/features/expense/index.ts
+++ b/src/features/expense/index.ts
@@ -1,0 +1,10 @@
+export { default as Expense } from './Expense';
+export { ExpenseForm } from './ExpenseForm';
+export { ExpenseList } from './ExpenseList';
+export { useExpenseStore } from './useExpenseStore';
+export type {
+  ExpenseEntry,
+  ExpenseState,
+  ExpenseActions,
+  ExpenseStore,
+} from './useExpenseStore';

--- a/src/features/expense/useExpenseStore.ts
+++ b/src/features/expense/useExpenseStore.ts
@@ -1,0 +1,48 @@
+import { create } from 'zustand';
+
+export interface ExpenseEntry {
+  id: string;
+  date: string;
+  category: string;
+  amount: number;
+  note?: string;
+}
+
+export interface ExpenseState {
+  expenses: ExpenseEntry[];
+}
+
+export interface ExpenseActions {
+  addExpense: (entry: Omit<ExpenseEntry, 'id'>) => void;
+  updateExpense: (id: string, entry: Partial<ExpenseEntry>) => void;
+  deleteExpense: (id: string) => void;
+  reset: () => void;
+}
+
+export type ExpenseStore = ExpenseState & ExpenseActions;
+
+const initialState: ExpenseState = {
+  expenses: [],
+};
+
+export const useExpenseStore = create<ExpenseStore>((set) => ({
+  ...initialState,
+  addExpense: (entry) =>
+    set((state) => ({
+      expenses: [
+        ...state.expenses,
+        { id: crypto.randomUUID(), ...entry },
+      ],
+    })),
+  updateExpense: (id, entry) =>
+    set((state) => ({
+      expenses: state.expenses.map((e) =>
+        e.id === id ? { ...e, ...entry } : e
+      ),
+    })),
+  deleteExpense: (id) =>
+    set((state) => ({
+      expenses: state.expenses.filter((e) => e.id !== id),
+    })),
+  reset: () => set(initialState),
+}));

--- a/src/test/expenseComponent.test.tsx
+++ b/src/test/expenseComponent.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ThemeProvider, CssBaseline } from '@mui/material';
+import { CustomThemeProvider } from '../contexts/ThemeContext';
+import { createModernTheme } from '../theme/modernTheme';
+import Expense from '../features/expense/Expense';
+
+const TestProvider = ({ children }: { children: React.ReactNode }) => {
+  const theme = createModernTheme({ mode: 'light', highContrast: false, fontSize: 'medium' });
+  return (
+    <CustomThemeProvider>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </ThemeProvider>
+    </CustomThemeProvider>
+  );
+};
+
+describe('Expense component', () => {
+  it('renders heading', () => {
+    const { getByText } = render(
+      <TestProvider>
+        <Expense />
+      </TestProvider>
+    );
+    expect(getByText('経費管理')).toBeInTheDocument();
+  });
+});

--- a/src/test/expenseStore.test.ts
+++ b/src/test/expenseStore.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useExpenseStore } from '../features/expense/useExpenseStore';
+
+// Helper to reset store before each test
+const resetStore = () => {
+  const { reset } = useExpenseStore.getState();
+  reset();
+};
+
+describe('useExpenseStore', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it('adds a new expense entry', () => {
+    const { addExpense, expenses } = useExpenseStore.getState();
+    addExpense({ date: '2024-01-01', category: '旅費', amount: 1000, note: '' });
+    expect(useExpenseStore.getState().expenses.length).toBe(1);
+    expect(useExpenseStore.getState().expenses[0].category).toBe('旅費');
+  });
+
+  it('updates an expense entry', () => {
+    const { addExpense, updateExpense } = useExpenseStore.getState();
+    addExpense({ date: '2024-01-01', category: '旅費', amount: 1000, note: '' });
+    const id = useExpenseStore.getState().expenses[0].id;
+    updateExpense(id, { amount: 2000 });
+    expect(useExpenseStore.getState().expenses[0].amount).toBe(2000);
+  });
+});


### PR DESCRIPTION
## Summary
- implement expense management components and zustand store
- expose new feature via index export
- integrate Expense tab into the app
- add navigation items for expense management
- create basic tests for component rendering and store

## Testing
- `npm test` *(fails: vitest not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685f754e261083339bd51b4e226c04c8