### PR TITLE
Add unit tests for Timecard store and component

### DIFF
--- a/src/test/timecardComponent.test.tsx
+++ b/src/test/timecardComponent.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ThemeProvider, CssBaseline } from '@mui/material';
+import { CustomThemeProvider } from '../contexts/ThemeContext';
+import { createModernTheme } from '../theme/modernTheme';
+import Timecard from '../features/timecard/Timecard';
+
+const TestProvider = ({ children }: { children: React.ReactNode }) => {
+  const theme = createModernTheme({ mode: 'light', highContrast: false, fontSize: 'medium' });
+  return (
+    <CustomThemeProvider>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </ThemeProvider>
+    </CustomThemeProvider>
+  );
+};
+
+describe('Timecard component', () => {
+  it('renders heading', () => {
+    const { getByText } = render(
+      <TestProvider>
+        <Timecard />
+      </TestProvider>
+    );
+    expect(getByText('タイムカード管理')).toBeInTheDocument();
+  });
+});

--- a/src/test/timecardStore.test.ts
+++ b/src/test/timecardStore.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useTimecardStore, calculateMonthlyHours } from '../features/timecard/useTimecardStore';
+
+const resetStore = () => {
+  const { reset } = useTimecardStore.getState();
+  reset();
+};
+
+describe('useTimecardStore', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it('adds a new timecard entry', () => {
+    const { addEntry } = useTimecardStore.getState();
+    addEntry({
+      date: '2024-01-01',
+      startTime: '09:00',
+      endTime: '18:00',
+      note: '',
+      isAbsence: false,
+    });
+    expect(useTimecardStore.getState().entries.length).toBe(1);
+    expect(useTimecardStore.getState().entries[0].date).toBe('2024-01-01');
+  });
+
+  it('updates a timecard entry', () => {
+    const { addEntry, updateEntry } = useTimecardStore.getState();
+    addEntry({
+      date: '2024-01-01',
+      startTime: '09:00',
+      endTime: '18:00',
+      note: '',
+      isAbsence: false,
+    });
+    const id = useTimecardStore.getState().entries[0].id;
+    updateEntry(id, { endTime: '17:30' });
+    expect(useTimecardStore.getState().entries[0].endTime).toBe('17:30');
+  });
+
+  it('deletes a timecard entry', () => {
+    const { addEntry, deleteEntry } = useTimecardStore.getState();
+    addEntry({
+      date: '2024-01-01',
+      startTime: '09:00',
+      endTime: '18:00',
+      note: '',
+      isAbsence: false,
+    });
+    const id = useTimecardStore.getState().entries[0].id;
+    deleteEntry(id);
+    expect(useTimecardStore.getState().entries.length).toBe(0);
+  });
+
+  it('calculates monthly hours correctly', () => {
+    const { addEntry } = useTimecardStore.getState();
+    addEntry({ date: '2024-01-01', startTime: '09:00', endTime: '18:00', note: '', isAbsence: false });
+    addEntry({ date: '2024-01-02', startTime: '10:00', endTime: '17:00', note: '', isAbsence: false });
+    const hours = calculateMonthlyHours(useTimecardStore.getState().entries);
+    expect(hours['2024-01']).toBeCloseTo(16);
+  });
+});


### PR DESCRIPTION
## Summary
- add `timecardStore` unit tests covering CRUD and summary calculation
- add render test for `Timecard` component

## Testing
- `npm run lint` *(fails: cannot find eslint-plugin-storybook)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8e3ba69c8333a0cf9c45aeeb62e1